### PR TITLE
updates config to work with stack 2.5.1

### DIFF
--- a/stack.yaml
+++ b/stack.yaml
@@ -8,22 +8,24 @@ flags:
     unicode_collation: false
     test_citeproc: false
     debug: false
+
 packages:
-- '.'
+- .
 # See https://github.com/haskell-foundation/foundation/pull/503
 # We can go back to released foundation when this is fixed.
-- location:
-    git: https://github.com/jgm/foundation
-    commit: '4294e39'
-  subdirs:
-  - foundation
-  extra-dep: true
+
 extra-deps:
+- git: https://github.com/jgm/foundation
+  commit: 4294e39b6a8b1146fd280ca2654cd08dd324ad73
+  subdirs:
+    - foundation
 - github: jgm/pandoc-citeproc
   commit: 596872a5a5dec15f4c8848cf87dd72e0ef2f160d
 - haddock-library-1.6.0
 - HsYAML-0.1.1.1
 - yaml-0.9.0
+
 ghc-options:
    "$locals": -fhide-source-paths -XNoImplicitPrelude
+
 resolver: lts-12.6


### PR DESCRIPTION
"stack setup" returns this error
"Could not parse '/Users/user/Projects/pandoc/stack.yaml':
Aeson exception:
Error in $.packages[0]: failed to parse field 'packages': parsing Text failed, expected String, but encountered Object
See http://docs.haskellstack.org/en/stable/yaml_configuration/"

the suggested resource outlines the changes made in newer versions of stack for the YAML configuration. changed the YAML configuration accordingly.